### PR TITLE
PTSampler's evidence integral simplified; bug fixed.

### DIFF
--- a/emcee/ptsampler.py
+++ b/emcee/ptsampler.py
@@ -580,18 +580,10 @@ class PTSampler(Sampler):
 
         istart = int(logls.shape[2] * fburnin + 0.5)
         mean_logls = np.mean(np.mean(logls, axis=1)[:, istart:], axis=1)
+        betas = self._betas
 
-        if self._betas[-1] != 0:
-            betas = np.concatenate((self._betas, [0]))
-            betas2 = np.concatenate((self._betas[::2], [0]))
-
-            # Duplicate mean log-likelihood of hottest chain as a best guess for beta = 0.
-            mean_logls2 = np.concatenate((mean_logls[::2], [mean_logls[-1]]))
-            mean_logls = np.concatenate((mean_logls, [mean_logls[-1]]))
-        else:
-            betas = self._betas
-            betas2 = np.concatenate((self._betas[:-1:2], [0]))
-            mean_logls2 = np.concatenate((mean_logls[:-1:2], mean_logls[-1]))
+        betas2 = betas[::2]
+        mean_logls2 = mean_logls[::2]
 
         lnZ = -np.trapz(mean_logls, betas)
         lnZ2 = -np.trapz(mean_logls2, betas2)


### PR DESCRIPTION
There was a bug in one of the branches of the if statement in PTSampler's evidence integral.  I radically simplified the code (just use np.trapz) at the cost of some accuracy in the error estimate.